### PR TITLE
feat: describePrivate

### DIFF
--- a/describe.spec.ts
+++ b/describe.spec.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+
+import { describe as describeSclElement } from "./describe.js";
+
+const testScl = new DOMParser().parseFromString(
+  `<SCL
+      xmlns="http://www.iec.ch/61850/2003/SCL"
+      xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates"
+      xmlns:ens="http://somevalidURI"
+    >
+      <Private type="someType" desc="someDesc" sxy:x="10" ens:some="someOtherNameSpace">
+        <![CDATA[some comment]]>
+        <IED name="somePrivateIED"/>
+      </Private>
+      <ens:SomeNonSCLElement />
+    </SCL>`,
+  "application/xml"
+);
+
+const privateElement = testScl.querySelector("Private")!;
+const sclElement = testScl.querySelector("SCL")!;
+const SomeNonSCLElement = testScl.querySelector("SomeNonSCLElement")!;
+
+describe("Describe SCL elements function", () => {
+  it("returns undefined with missing describe function", () =>
+    expect(describeSclElement(SomeNonSCLElement)).to.be.undefined);
+
+  it("returns undefined with missing describe function", () =>
+    expect(describeSclElement(sclElement)).to.be.undefined);
+
+  it("returns outerHTML for SCL element Private ", () =>
+    expect(describeSclElement(privateElement)).to
+      .equal(`<Private xmlns="http://www.iec.ch/61850/2003/SCL" type="someType" desc="someDesc" xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates" sxy:x="10" xmlns:ens="http://somevalidURI" ens:some="someOtherNameSpace">
+        <![CDATA[some comment]]>
+        <IED name="somePrivateIED"/>
+      </Private>`));
+});

--- a/describe.ts
+++ b/describe.ts
@@ -1,0 +1,13 @@
+import { Private, PrivateDescription } from "./describe/Private.js";
+
+export type Description = PrivateDescription;
+
+const sclElementDescriptors: Partial<
+  Record<string, (element: Element) => Description>
+> = {
+  Private,
+};
+
+export function describe(element: Element): Description | undefined {
+  return sclElementDescriptors[element.tagName]?.(element);
+}

--- a/describe/Private.spec.ts
+++ b/describe/Private.spec.ts
@@ -1,0 +1,28 @@
+import { expect } from "chai";
+
+import { Private } from "./Private.js";
+
+const privateElement = new DOMParser()
+  .parseFromString(
+    `<SCL
+      xmlns="http://www.iec.ch/61850/2003/SCL"
+      xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates"
+      xmlns:ens="http://somevalidURI"
+    >
+      <Private type="someType" desc="someDesc" sxy:x="10" ens:some="someOtherNameSpace">
+        <![CDATA[some comment]]>
+        <IED name="somePrivateIED"/>
+      </Private>
+    </SCL>`,
+    "application/xml"
+  )
+  .querySelector("Private")!;
+
+describe("Description for SCL element Private", () => {
+  it("returns outerHTML", () =>
+    expect(Private(privateElement)).to
+      .equal(`<Private xmlns="http://www.iec.ch/61850/2003/SCL" type="someType" desc="someDesc" xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates" sxy:x="10" xmlns:ens="http://somevalidURI" ens:some="someOtherNameSpace">
+        <![CDATA[some comment]]>
+        <IED name="somePrivateIED"/>
+      </Private>`));
+});

--- a/describe/Private.ts
+++ b/describe/Private.ts
@@ -1,0 +1,6 @@
+export type PrivateDescription = string;
+
+export function Private(element: Element): PrivateDescription {
+  // TODO(#14): canonicalize the XML string
+  return element.outerHTML;
+}


### PR DESCRIPTION
Closes #10 

I have chosen to use `outerHTML` instead of serialize. From what I have researched, it is more performant. Please bear in mind that we need to adapt this function and make sure the Private elements are canonicalization. 