### PR TITLE
describe Text

### DIFF
--- a/describe.spec.ts
+++ b/describe.spec.ts
@@ -12,6 +12,7 @@ const testScl = new DOMParser().parseFromString(
         <![CDATA[some comment]]>
         <IED name="somePrivateIED"/>
       </Private>
+      <Text>Some detailed description</Text>
       <ens:SomeNonSCLElement />
     </SCL>`,
   "application/xml"
@@ -20,6 +21,7 @@ const testScl = new DOMParser().parseFromString(
 const privateElement = testScl.querySelector("Private")!;
 const sclElement = testScl.querySelector("SCL")!;
 const SomeNonSCLElement = testScl.querySelector("SomeNonSCLElement")!;
+const textElement = testScl.querySelector("Text")!;
 
 describe("Describe SCL elements function", () => {
   it("returns undefined with missing describe function", () =>
@@ -34,4 +36,9 @@ describe("Describe SCL elements function", () => {
         <![CDATA[some comment]]>
         <IED name="somePrivateIED"/>
       </Private>`));
+
+  it("returns outerHTML for SCL element Text ", () =>
+    expect(describeSclElement(textElement)).to.equal(
+      `<Text xmlns="http://www.iec.ch/61850/2003/SCL">Some detailed description</Text>`
+    ));
 });

--- a/describe.ts
+++ b/describe.ts
@@ -1,11 +1,13 @@
 import { Private, PrivateDescription } from "./describe/Private.js";
+import { Text, TextDescription } from "./describe/Text.js";
 
-export type Description = PrivateDescription;
+export type Description = PrivateDescription | TextDescription;
 
 const sclElementDescriptors: Partial<
   Record<string, (element: Element) => Description>
 > = {
   Private,
+  Text,
 };
 
 export function describe(element: Element): Description | undefined {

--- a/describe/Text.spec.ts
+++ b/describe/Text.spec.ts
@@ -1,0 +1,28 @@
+import { expect } from "chai";
+
+import { Text } from "./Text.js";
+
+const textElement = new DOMParser()
+  .parseFromString(
+    `<SCL
+      xmlns="http://www.iec.ch/61850/2003/SCL"
+      xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates"
+      xmlns:ens="http://somevalidURI"
+    >
+      <Text desc="someDesc" sxy:x="10" ens:some="someOtherNameSpace">
+        <![CDATA[some comment]]>
+        Some more detailed description than the desc field
+      </Text>
+    </SCL>`,
+    "application/xml"
+  )
+  .querySelector("Text")!;
+
+describe("Description for SCL element Text", () => {
+  it("returns outerHTML", () =>
+    expect(Text(textElement)).to
+      .equal(`<Text xmlns="http://www.iec.ch/61850/2003/SCL" desc="someDesc" xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates" sxy:x="10" xmlns:ens="http://somevalidURI" ens:some="someOtherNameSpace">
+        <![CDATA[some comment]]>
+        Some more detailed description than the desc field
+      </Text>`));
+});

--- a/describe/Text.ts
+++ b/describe/Text.ts
@@ -1,0 +1,6 @@
+export type TextDescription = string;
+
+export function Text(element: Element): TextDescription {
+  // TODO(#14): canonicalize the XML string
+  return element.outerHTML;
+}


### PR DESCRIPTION
Closes #11 

I was not sure whether to have those differentiate, as it does exactly the same thing. I furthermore am not sure when `xs:any` will do as well and here we are speaking about unknown tag that can be potentially in the file. The only thing speaking for it is that in the future we might need to deffirentiate and it feels more complete to me. 

What do you think about this?