### PR TITLE
feat: describe EnumType

### DIFF
--- a/describe.spec.ts
+++ b/describe.spec.ts
@@ -8,37 +8,60 @@ const testScl = new DOMParser().parseFromString(
       xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates"
       xmlns:ens="http://somevalidURI"
     >
-      <Private type="someType" desc="someDesc" sxy:x="10" ens:some="someOtherNameSpace">
-        <![CDATA[some comment]]>
-        <IED name="somePrivateIED"/>
-      </Private>
-      <Text>Some detailed description</Text>
-      <ens:SomeNonSCLElement />
+      <DataTypeTemplates>
+      <EnumType id="someID">
+        <Private type="someType" desc="someDesc" sxy:x="10" ens:some="someOtherNameSpace">
+          <![CDATA[some comment]]>
+          <IED name="somePrivateIED"/>
+        </Private>
+        <Text>Some detailed description</Text>
+        <ens:SomeNonSCLElement />
+        <EnumVal ord="1">A</EnumVal>
+      </EnumType>
+      <EnumType id="someDiffID" >
+        <Private type="someType" desc="someDesc" sxy:x="10" ens:some="someOtherNameSpace">
+          <![CDATA[some comment]]>
+          <IED name="somePrivateIED"/>
+        </Private>
+        <Text>Some detailed description</Text>
+        <ens:SomeNonSCLElement />
+        <EnumVal ord="1"></EnumVal>
+      </EnumType>
+      <EnumType id="someOtherID">
+        <Private type="someType" desc="someDesc" sxy:x="10" ens:some="someOtherNameSpace">
+          <![CDATA[some comment]]>
+          <IED name="somePrivateIED"/>
+        </Private>
+        <Text>Some detailed description</Text>
+        <ens:SomeNonSCLElement />
+        <EnumVal ord="1">A</EnumVal>
+      </EnumType>
+      </DataTypeTemplates>
     </SCL>`,
   "application/xml"
 );
 
-const privateElement = testScl.querySelector("Private")!;
 const sclElement = testScl.querySelector("SCL")!;
-const SomeNonSCLElement = testScl.querySelector("SomeNonSCLElement")!;
-const textElement = testScl.querySelector("Text")!;
+const omeNonSCLElement = testScl.querySelector("SomeNonSCLElement")!;
+
+const baseEnumType = testScl.querySelector("#someID")!;
+const diffEnumType = testScl.querySelector("#someDiffID")!;
+const equalEnumType = testScl.querySelector("#someOtherID")!;
 
 describe("Describe SCL elements function", () => {
   it("returns undefined with missing describe function", () =>
-    expect(describeSclElement(SomeNonSCLElement)).to.be.undefined);
+    expect(describeSclElement(omeNonSCLElement)).to.be.undefined);
 
   it("returns undefined with missing describe function", () =>
     expect(describeSclElement(sclElement)).to.be.undefined);
 
-  it("returns outerHTML for SCL element Private ", () =>
-    expect(describeSclElement(privateElement)).to
-      .equal(`<Private xmlns="http://www.iec.ch/61850/2003/SCL" type="someType" desc="someDesc" xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates" sxy:x="10" xmlns:ens="http://somevalidURI" ens:some="someOtherNameSpace">
-        <![CDATA[some comment]]>
-        <IED name="somePrivateIED"/>
-      </Private>`));
+  it("return equal description with semantically equal SCL element", () =>
+    expect(describeSclElement(baseEnumType)).to.deep.equal(
+      describeSclElement(equalEnumType)
+    ));
 
-  it("returns outerHTML for SCL element Text ", () =>
-    expect(describeSclElement(textElement)).to.equal(
-      `<Text xmlns="http://www.iec.ch/61850/2003/SCL">Some detailed description</Text>`
+  it("return different description with semantically unequal SCL element", () =>
+    expect(describeSclElement(diffEnumType)).to.not.deep.equal(
+      describeSclElement(equalEnumType)
     ));
 });

--- a/describe.ts
+++ b/describe.ts
@@ -1,13 +1,18 @@
 import { Private, PrivateDescription } from "./describe/Private.js";
 import { Text, TextDescription } from "./describe/Text.js";
+import { EnumType, EnumTypeDescription } from "./describe/EnumType.js";
 
-export type Description = PrivateDescription | TextDescription;
+export type Description =
+  | PrivateDescription
+  | TextDescription
+  | EnumTypeDescription;
 
 const sclElementDescriptors: Partial<
   Record<string, (element: Element) => Description>
 > = {
   Private,
   Text,
+  EnumType,
 };
 
 export function describe(element: Element): Description | undefined {

--- a/describe/BaseElement.spec.ts
+++ b/describe/BaseElement.spec.ts
@@ -1,0 +1,112 @@
+import { expect } from "chai";
+import { describeBaseElement } from "./BaseElement";
+
+const scl = new DOMParser().parseFromString(
+  `<SCL
+      xmlns="http://www.iec.ch/61850/2003/SCL"
+      xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates"
+      xmlns:ens="http://somevalidURI"
+    >
+      <EnumType id="someEqual" desc="someDesc" ens:some="someOtherNamespace" sxy:x="1" sxy:y="3">
+        <Private type="somePrivate">SomePrivateContent</Private>
+        <Private type="someOtherPrivate">SomeOtherPrivateContent</Private>
+        <Text>SomeTextContent</Text>      
+        <EnumVal ord="-1">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+      </EnumType>
+      <EnumType id="someDifferent" desc="someDesc" ens:some="someOtherNamespace" sxy:x="1">
+        <Private type="somePrivate">SomePrivateContent</Private>
+        <Private type="someOtherPrivate">SomeOtherPrivateContent</Private>
+        <Text>SomeTextContent</Text>      
+        <EnumVal ord="-1">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+      </EnumType>
+      <EnumType id="someDifferent1" desc="someDesc" ens:some="someOtherNamespace" sxy:x="1" sxy:y="3">
+        <Private type="somePrivate">SomePrivateContent</Private>
+        <Text>SomeTextContent</Text>      
+        <EnumVal ord="-1">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+      </EnumType>
+      <EnumType id="someDifferent2" desc="someDesc" ens:some="someOtherNamespace" sxy:x="1" sxy:y="3">
+        <Private type="someOtherPrivate">SomeOtherPrivateContent</Private>
+        <Private type="somePrivate">SomePrivateContent</Private>
+        <Text>SomeTextContent</Text>      
+        <EnumVal ord="-1">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+      </EnumType>
+      <EnumType id="someDifferent3" desc="someDesc" ens:some="someOtherNamespace" sxy:x="1" sxy:y="3">
+        <Private type="somePrivate">SomePrivateContent</Private>
+        <Private type="someOtherPrivate">SomeOtherPrivateContent</Private>
+        <EnumVal ord="-1">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+      </EnumType>
+      <EnumType id="someOtherEqual" sxy:x="1" ens:some="someOtherNamespace"  sxy:y="3">
+        <Text>SomeTextContent</Text>
+        <Private type="somePrivate">SomePrivateContent</Private>
+        <Private type="someOtherPrivate">SomeOtherPrivateContent</Private>
+        <EnumVal ord="-1">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+      </EnumType>
+    </SCL>`,
+  "application/xml"
+);
+
+const baseElement = scl.querySelector("#someEqual")!;
+const diffElement1 = scl.querySelector("#someDifferent")!;
+const diffElement2 = scl.querySelector("#someDifferent1")!;
+const diffElement3 = scl.querySelector("#someDifferent2")!;
+const diffElement4 = scl.querySelector("#someDifferent3")!;
+const equalElement = scl.querySelector("#someOtherEqual")!;
+
+describe("Description for SCL element typed tBaseElement", () => {
+  it("return a string array each per child Private element", () => {
+    const privates = describeBaseElement(baseElement).privates;
+    expect(privates).to.not.be.undefined;
+    expect(privates.length).to.equal(2);
+  });
+
+  it("return a string array each per child Text element", () => {
+    const texts = describeBaseElement(baseElement).texts;
+    expect(texts).to.not.be.undefined;
+    expect(texts.length).to.equal(1);
+  });
+
+  it("return a record for attributes outside the SCL target namespace", () => {
+    const attributes = describeBaseElement(baseElement).eNSAttributes;
+    expect(attributes).to.not.be.undefined;
+    expect(attributes["http://somevalidURI"]["ens:some"]).to.equal(
+      "someOtherNamespace"
+    );
+    expect(
+      attributes["http://www.iec.ch/61850/2003/SCLcoordinates"]["sxy:x"]
+    ).to.equal("1");
+    expect(
+      attributes["http://www.iec.ch/61850/2003/SCLcoordinates"]["sxy:y"]
+    ).to.equal("3");
+  });
+
+  it("returns same description with semantically equal SCL element", () =>
+    expect(describeBaseElement(baseElement)).to.deep.equal(
+      describeBaseElement(equalElement)
+    ));
+
+  it("returns different description with unequal extra namespace attributes", () =>
+    expect(describeBaseElement(diffElement1)).to.not.deep.equal(
+      describeBaseElement(equalElement)
+    ));
+
+  it("returns different description with unequal Private child element", () =>
+    expect(describeBaseElement(diffElement2)).to.not.deep.equal(
+      describeBaseElement(equalElement)
+    ));
+
+  it("returns different description with unequal Text child element", () =>
+    expect(describeBaseElement(diffElement4)).to.not.deep.equal(
+      describeBaseElement(equalElement)
+    ));
+
+  it("returns different description with unequal Private child element order", () =>
+    expect(describeBaseElement(diffElement3)).to.not.deep.equal(
+      describeBaseElement(equalElement)
+    ));
+});

--- a/describe/BaseElement.ts
+++ b/describe/BaseElement.ts
@@ -1,0 +1,37 @@
+import { Private } from "./Private.js";
+import { Text } from "./Text.js";
+
+type ExtensionNSAttributes = Record<string, Record<string, string | null>>;
+
+export interface BaseElementDescription {
+  /** canonicalized XML of `Private` elements */
+  privates: string[];
+  /** some representation of `Text` elements */
+  texts: string[];
+  /** attributes from other namespace */
+  eNSAttributes: ExtensionNSAttributes;
+}
+
+export function describeBaseElement(element: Element): BaseElementDescription {
+  const baseElement: BaseElementDescription = {
+    privates: [],
+    texts: [],
+    eNSAttributes: {},
+  };
+
+  Array.from(element.children).forEach((child) => {
+    if (child.tagName === "Private") baseElement.privates.push(Private(child));
+    if (child.tagName === "Text") baseElement.texts.push(Text(child));
+  });
+
+  Array.from(element.attributes).forEach((attr) => {
+    if (attr.namespaceURI) {
+      if (!baseElement.eNSAttributes[attr.namespaceURI])
+        baseElement.eNSAttributes[attr.namespaceURI] = {};
+
+      baseElement.eNSAttributes[attr.namespaceURI][attr.name] = attr.value;
+    }
+  });
+
+  return baseElement;
+}

--- a/describe/EnumType.spec.ts
+++ b/describe/EnumType.spec.ts
@@ -1,0 +1,88 @@
+import { expect } from "chai";
+
+import { EnumType } from "./EnumType.js";
+
+const scl = new DOMParser().parseFromString(
+  `<SCL
+      xmlns="http://www.iec.ch/61850/2003/SCL"
+      xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates"
+      xmlns:ens="http://somevalidURI"
+    >
+      <EnumType id="someEqual" desc="someDesc">     
+        <EnumVal ord="-1" desc="someDesc">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+        <EnumVal ord="-23"><someitem/></EnumVal>
+      </EnumType>
+      <EnumType id="someDifferent">     
+        <EnumVal ord="-1" desc="someDesc">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+        <EnumVal ord="-23"></EnumVal>
+      </EnumType>
+      <EnumType id="someDifferent1" desc="someDesc">     
+        <EnumVal ord="-1">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+        <EnumVal ord="-23"></EnumVal>
+      </EnumType>
+      <EnumType id="someDifferent2" desc="someDesc">     
+        <EnumVal ord="-3" desc="someDesc">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+        <EnumVal ord="-23"></EnumVal>
+      </EnumType>
+      <EnumType id="someDifferent3" desc="someDesc">     
+        <EnumVal ord="-1" desc="someDesc">SomeOtherContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+        <EnumVal ord="-23"></EnumVal>
+      </EnumType>
+      <EnumType id="someEqual1" desc="someDesc">     
+        <EnumVal ord="-1" desc="someDesc">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+        <EnumVal ord="-23"></EnumVal>
+        <EnumVal >someInvalidSemantic</EnumVal>
+        <EnumVal ord="someInvalidOrd">someOtherInvalidSemantic</EnumVal>
+      </EnumType>
+      <EnumType id="someOtherEqual" desc="someDesc">     
+        <EnumVal ord="-1" desc="someDesc">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+        <EnumVal ord="-23"></EnumVal>
+      </EnumType>
+    </SCL>`,
+  "application/xml"
+);
+
+const equalEnumType = scl.querySelector("#someEqual")!;
+const diffEnumVal1 = scl.querySelector("#someDifferent")!;
+const diffEnumVal2 = scl.querySelector("#someDifferent1")!;
+const diffEnumVal3 = scl.querySelector("#someDifferent2")!;
+const diffEnumVal4 = scl.querySelector("#someDifferent3")!;
+const diffEnumVal5 = scl.querySelector("#someEqual1")!;
+const baseEnumType = scl.querySelector("#someOtherEqual")!;
+
+describe("Description for SCL schema element tBaseElement", () => {
+  it("returns property desc with existing desc attribute", () =>
+    expect(EnumType(baseEnumType)).to.haveOwnProperty("desc", "someDesc"));
+
+  it("returns property enumVals with existing EnumVal children", () => {
+    const enumVals = EnumType(baseEnumType).enumVals;
+    const enumVal1 = enumVals[-1];
+    expect(enumVal1).to.haveOwnProperty("desc", "someDesc");
+    expect(enumVal1).to.haveOwnProperty("content", "SomeContent");
+  });
+
+  it("returns same description with semantically equal EnumType's", () =>
+    expect(EnumType(baseEnumType)).to.deep.equal(EnumType(equalEnumType)));
+
+  it("returns different description with unequal EnumType desc attribute", () =>
+    expect(EnumType(baseEnumType)).to.not.deep.equal(EnumType(diffEnumVal1)));
+
+  it("returns different description with unequal EnumVal desc attribute", () =>
+    expect(EnumType(baseEnumType)).to.not.deep.equal(EnumType(diffEnumVal2)));
+
+  it("returns different description with unequal EnumVal ord attributes", () =>
+    expect(EnumType(baseEnumType)).to.not.deep.equal(EnumType(diffEnumVal3)));
+
+  it("returns different description with unequal Private child element order", () =>
+    expect(EnumType(baseEnumType)).to.not.deep.equal(EnumType(diffEnumVal4)));
+
+  it("ignore schema invalid ord definition", () =>
+    expect(EnumType(baseEnumType)).to.deep.equal(EnumType(diffEnumVal5)));
+});

--- a/describe/EnumType.ts
+++ b/describe/EnumType.ts
@@ -1,0 +1,27 @@
+import { NamingDescription, describeNaming } from "./Naming.js";
+
+export interface EnumTypeDescription extends NamingDescription {
+  enumVals: Record<number, { desc: string; content: string }>;
+}
+
+export function EnumType(element: Element): EnumTypeDescription {
+  const enumTypeDesc: EnumTypeDescription = {
+    ...describeNaming(element),
+    enumVals: {},
+  };
+
+  Array.from(element.getElementsByTagName("EnumVal")).forEach((enumVal) => {
+    const ordAttr = enumVal.getAttribute("ord");
+    if (!ordAttr) return;
+
+    const ord = parseInt(ordAttr, 10);
+    if (isNaN(ord)) return;
+
+    enumTypeDesc.enumVals[ord] = {
+      desc: enumVal.getAttribute("desc") ?? "",
+      content: enumVal.textContent || "",
+    };
+  });
+
+  return enumTypeDesc;
+}

--- a/describe/Naming.spec.ts
+++ b/describe/Naming.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from "chai";
+import { describeNaming } from "./Naming.js";
+
+const scl = new DOMParser().parseFromString(
+  `<SCL
+      xmlns="http://www.iec.ch/61850/2003/SCL"
+    >
+      <EnumType id="someEqual" desc="someDesc" />
+      <EnumType id="someDifferent" />
+      <EnumType id="someOtherEqual" desc="someDesc" />
+    </SCL>`,
+  "application/xml"
+);
+
+const baseElement = scl.querySelector("#someEqual")!;
+const diffElement = scl.querySelector("#someDifferent")!;
+const equalElement = scl.querySelector("#someOtherEqual")!;
+
+describe("Description for SCL schema element tBaseElement", () => {
+  it("returns property desc with existing desc attribute", () =>
+    expect(describeNaming(baseElement)).to.haveOwnProperty("desc", "someDesc"));
+
+  it("returns same description with semantically equal Naming type SCL element", () =>
+    expect(describeNaming(baseElement)).to.deep.equal(
+      describeNaming(equalElement)
+    ));
+
+  it("returns different description with unequal Naming type SCL element", () =>
+    expect(describeNaming(diffElement)).to.not.deep.equal(
+      describeNaming(equalElement)
+    ));
+});

--- a/describe/Naming.ts
+++ b/describe/Naming.ts
@@ -1,0 +1,16 @@
+import { BaseElementDescription, describeBaseElement } from "./BaseElement";
+
+export interface NamingDescription extends BaseElementDescription {
+  desc?: string;
+}
+
+export function describeNaming(element: Element): NamingDescription {
+  const idNameDescription: NamingDescription = {
+    ...describeBaseElement(element),
+  };
+
+  if (element.getAttribute("desc"))
+    idNameDescription.desc = element.getAttribute("desc")!;
+
+  return idNameDescription;
+}


### PR DESCRIPTION
Closes #2 

The first interesting one. I have added a `describeBaseElement` function as it will always be needed with nearly every SCL element. The name is on purpose not following the naming convention as I would not want it to be exported to the describe function also in a later stage.