### PR TITLE
fix(BaseElement): sort extension attributes

### DIFF
--- a/describe.spec.ts
+++ b/describe.spec.ts
@@ -56,12 +56,12 @@ describe("Describe SCL elements function", () => {
     expect(describeSclElement(sclElement)).to.be.undefined);
 
   it("return equal description with semantically equal SCL element", () =>
-    expect(describeSclElement(baseEnumType)).to.deep.equal(
-      describeSclElement(equalEnumType)
+    expect(JSON.stringify(describeSclElement(baseEnumType))).to.equal(
+      JSON.stringify(describeSclElement(equalEnumType))
     ));
 
   it("return different description with semantically unequal SCL element", () =>
-    expect(describeSclElement(diffEnumType)).to.not.deep.equal(
-      describeSclElement(equalEnumType)
+    expect(JSON.stringify(describeSclElement(diffEnumType))).to.not.equal(
+      JSON.stringify(describeSclElement(equalEnumType))
     ));
 });

--- a/describe/BaseElement.spec.ts
+++ b/describe/BaseElement.spec.ts
@@ -40,7 +40,14 @@ const scl = new DOMParser().parseFromString(
         <EnumVal ord="-1">SomeContent</EnumVal>
         <EnumVal ord="13">SomeOtherContent</EnumVal>
       </EnumType>
-      <EnumType id="someOtherEqual" sxy:x="1" ens:some="someOtherNamespace"  sxy:y="3">
+      <EnumType id="someDifferent4" desc="someDesc" sxy:y="3" ens:some="someOtherNamespace" sxy:x="1">
+        <Private type="somePrivate">SomePrivateContent</Private>
+        <Private type="someOtherPrivate">SomeOtherPrivateContent</Private>
+        <Text>SomeTextContent</Text>
+        <EnumVal ord="-1">SomeContent</EnumVal>
+        <EnumVal ord="13">SomeOtherContent</EnumVal>
+      </EnumType>
+      <EnumType id="someOtherEqual" ens:some="someOtherNamespace" sxy:x="1" sxy:y="3">
         <Text>SomeTextContent</Text>
         <Private type="somePrivate">SomePrivateContent</Private>
         <Private type="someOtherPrivate">SomeOtherPrivateContent</Private>
@@ -56,6 +63,7 @@ const diffElement1 = scl.querySelector("#someDifferent")!;
 const diffElement2 = scl.querySelector("#someDifferent1")!;
 const diffElement3 = scl.querySelector("#someDifferent2")!;
 const diffElement4 = scl.querySelector("#someDifferent3")!;
+const diffElement5 = scl.querySelector("#someDifferent4")!;
 const equalElement = scl.querySelector("#someOtherEqual")!;
 
 describe("Description for SCL element typed tBaseElement", () => {
@@ -86,27 +94,32 @@ describe("Description for SCL element typed tBaseElement", () => {
   });
 
   it("returns same description with semantically equal SCL element", () =>
-    expect(describeBaseElement(baseElement)).to.deep.equal(
-      describeBaseElement(equalElement)
+    expect(JSON.stringify(describeBaseElement(baseElement))).to.equal(
+      JSON.stringify(describeBaseElement(equalElement))
     ));
 
   it("returns different description with unequal extra namespace attributes", () =>
-    expect(describeBaseElement(diffElement1)).to.not.deep.equal(
-      describeBaseElement(equalElement)
+    expect(JSON.stringify(describeBaseElement(diffElement1))).to.not.equal(
+      JSON.stringify(describeBaseElement(equalElement))
     ));
 
   it("returns different description with unequal Private child element", () =>
-    expect(describeBaseElement(diffElement2)).to.not.deep.equal(
-      describeBaseElement(equalElement)
+    expect(JSON.stringify(describeBaseElement(diffElement2))).to.not.equal(
+      JSON.stringify(describeBaseElement(equalElement))
     ));
 
   it("returns different description with unequal Text child element", () =>
-    expect(describeBaseElement(diffElement4)).to.not.deep.equal(
-      describeBaseElement(equalElement)
+    expect(JSON.stringify(describeBaseElement(diffElement4))).to.not.equal(
+      JSON.stringify(describeBaseElement(equalElement))
     ));
 
   it("returns different description with unequal Private child element order", () =>
-    expect(describeBaseElement(diffElement3)).to.not.deep.equal(
-      describeBaseElement(equalElement)
+    expect(JSON.stringify(describeBaseElement(diffElement3))).to.not.equal(
+      JSON.stringify(describeBaseElement(equalElement))
+    ));
+
+  it("is insensitive to any attribute order", () =>
+    expect(JSON.stringify(describeBaseElement(diffElement5))).to.equal(
+      JSON.stringify(describeBaseElement(equalElement))
     ));
 });

--- a/describe/BaseElement.ts
+++ b/describe/BaseElement.ts
@@ -12,6 +12,28 @@ export interface BaseElementDescription {
   eNSAttributes: ExtensionNSAttributes;
 }
 
+function sortENsAttributes(
+  eNsAttributes: ExtensionNSAttributes
+): ExtensionNSAttributes {
+  return Object.keys(eNsAttributes)
+    .sort()
+    .reduce((accURIs: ExtensionNSAttributes, key) => {
+      const eNsAttribute = eNsAttributes[key];
+
+      const sortedENsAttribute = Object.keys(eNsAttribute)
+        .sort()
+        .reduce((accAttributes: Record<string, string | null>, key) => {
+          accAttributes[key] = eNsAttribute[key];
+
+          return accAttributes;
+        }, {});
+
+      accURIs[key] = sortedENsAttribute;
+
+      return accURIs;
+    }, {});
+}
+
 export function describeBaseElement(element: Element): BaseElementDescription {
   const baseElement: BaseElementDescription = {
     privates: [],
@@ -24,14 +46,16 @@ export function describeBaseElement(element: Element): BaseElementDescription {
     if (child.tagName === "Text") baseElement.texts.push(Text(child));
   });
 
+  const eNsAttributes: ExtensionNSAttributes = {};
   Array.from(element.attributes).forEach((attr) => {
     if (attr.namespaceURI) {
-      if (!baseElement.eNSAttributes[attr.namespaceURI])
-        baseElement.eNSAttributes[attr.namespaceURI] = {};
+      if (!eNsAttributes[attr.namespaceURI])
+        eNsAttributes[attr.namespaceURI] = {};
 
-      baseElement.eNSAttributes[attr.namespaceURI][attr.name] = attr.value;
+      eNsAttributes[attr.namespaceURI][attr.name] = attr.value;
     }
   });
+  baseElement.eNSAttributes = sortENsAttributes(eNsAttributes);
 
   return baseElement;
 }

--- a/describe/EnumType.spec.ts
+++ b/describe/EnumType.spec.ts
@@ -69,20 +69,32 @@ describe("Description for SCL schema element tBaseElement", () => {
   });
 
   it("returns same description with semantically equal EnumType's", () =>
-    expect(EnumType(baseEnumType)).to.deep.equal(EnumType(equalEnumType)));
+    expect(JSON.stringify(EnumType(baseEnumType))).to.equal(
+      JSON.stringify(EnumType(equalEnumType))
+    ));
 
   it("returns different description with unequal EnumType desc attribute", () =>
-    expect(EnumType(baseEnumType)).to.not.deep.equal(EnumType(diffEnumVal1)));
+    expect(JSON.stringify(EnumType(baseEnumType))).to.not.equal(
+      JSON.stringify(EnumType(diffEnumVal1))
+    ));
 
   it("returns different description with unequal EnumVal desc attribute", () =>
-    expect(EnumType(baseEnumType)).to.not.deep.equal(EnumType(diffEnumVal2)));
+    expect(JSON.stringify(EnumType(baseEnumType))).to.not.equal(
+      JSON.stringify(EnumType(diffEnumVal2))
+    ));
 
   it("returns different description with unequal EnumVal ord attributes", () =>
-    expect(EnumType(baseEnumType)).to.not.deep.equal(EnumType(diffEnumVal3)));
+    expect(JSON.stringify(EnumType(baseEnumType))).to.not.equal(
+      JSON.stringify(EnumType(diffEnumVal3))
+    ));
 
   it("returns different description with unequal Private child element order", () =>
-    expect(EnumType(baseEnumType)).to.not.deep.equal(EnumType(diffEnumVal4)));
+    expect(JSON.stringify(EnumType(baseEnumType))).to.not.equal(
+      JSON.stringify(EnumType(diffEnumVal4))
+    ));
 
   it("ignore schema invalid ord definition", () =>
-    expect(EnumType(baseEnumType)).to.deep.equal(EnumType(diffEnumVal5)));
+    expect(JSON.stringify(EnumType(baseEnumType))).to.equal(
+      JSON.stringify(EnumType(diffEnumVal5))
+    ));
 });

--- a/describe/Naming.spec.ts
+++ b/describe/Naming.spec.ts
@@ -21,12 +21,12 @@ describe("Description for SCL schema element tBaseElement", () => {
     expect(describeNaming(baseElement)).to.haveOwnProperty("desc", "someDesc"));
 
   it("returns same description with semantically equal Naming type SCL element", () =>
-    expect(describeNaming(baseElement)).to.deep.equal(
-      describeNaming(equalElement)
+    expect(JSON.stringify(describeNaming(baseElement))).to.equal(
+      JSON.stringify(describeNaming(equalElement))
     ));
 
   it("returns different description with unequal Naming type SCL element", () =>
-    expect(describeNaming(diffElement)).to.not.deep.equal(
-      describeNaming(equalElement)
+    expect(JSON.stringify(describeNaming(diffElement))).to.not.equal(
+      JSON.stringify(describeNaming(equalElement))
     ));
 });


### PR DESCRIPTION
I am sorry I have to open an issue. It is quite obvious, and I hope clear for you. I am not fully sure whether the sorting function is good enough, but it does what it has to do tested by the regression test.