### PR TITLE
Describe LN

### DIFF
--- a/describe.spec.ts
+++ b/describe.spec.ts
@@ -8,7 +8,27 @@ const testScl = new DOMParser().parseFromString(
       xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates"
       xmlns:ens="http://somevalidURI"
     >
+      <IED name="IED">
+        <AccessPoint name="AP1">
+          <Server>
+            <LDevice inst="ldInst">
+              <LN lnClass="XCBR" inst="" lnType="baseXCBR"/>
+              <LN lnClass="XCBR" inst="" lnType="equalXCBR"/>
+              <LN lnClass="XCBR" inst="" lnType="diffXCBR"/>
+            </LDevice>
+          </Server>
+        </AccessPoint>
+      </IED>
       <DataTypeTemplates>
+        <LNodeType lnClass="XCBR" id="equalXCBR" >
+          <DO name="Beh" type="someEqualDOType" />
+        </LNodeType>
+        <LNodeType lnClass="XCBR" id="baseXCBR" >
+          <DO name="Beh" type="someBaseDOType" />
+        </LNodeType>
+        <LNodeType lnClass="XCBR" id="diffXCBR" >
+          <DO name="Beh" type="someDiffDOType" />
+        </LNodeType>
         <DOType cdc="SPS" id="someBaseDOType">
           <DA name="stVal" bType="Struct" fc="ST" type="someBaseDAType" />
         </DOType>
@@ -78,9 +98,9 @@ const baseEnumType = testScl.querySelector("#someID")!;
 const diffEnumType = testScl.querySelector("#someDiffID")!;
 const equalEnumType = testScl.querySelector("#someOtherID")!;
 
-const baseDOType = testScl.querySelector("#someBaseDOType")!;
-const equalDOType = testScl.querySelector("#someEqualDOType")!;
-const diffDOType = testScl.querySelector("#someDiffDOType")!;
+const baseLN = testScl.querySelector(`LN[lnType="baseXCBR"]`)!;
+const equalLN = testScl.querySelector(`LN[lnType="equalXCBR"]`)!;
+const diffLN = testScl.querySelector(`LN[lnType="diffXCBR"]`)!;
 
 describe("Describe SCL elements function", () => {
   it("returns undefined with missing describe function", () =>
@@ -99,13 +119,13 @@ describe("Describe SCL elements function", () => {
       JSON.stringify(describeSclElement(equalEnumType))
     ));
 
-  it("returns same description with semantically equal DOType's", () =>
-    expect(JSON.stringify(describeSclElement(baseDOType))).to.equal(
-      JSON.stringify(describeSclElement(equalDOType))
+  it("returns same description with semantically equal LN's", () =>
+    expect(JSON.stringify(describeSclElement(baseLN))).to.equal(
+      JSON.stringify(describeSclElement(equalLN))
     ));
 
-  it("returns different description with unequal DOType elements", () =>
-    expect(JSON.stringify(describeSclElement(baseDOType))).to.not.equal(
-      JSON.stringify(describeSclElement(diffDOType))
+  it("returns different description with unequal LN elements", () =>
+    expect(JSON.stringify(describeSclElement(baseLN))).to.not.equal(
+      JSON.stringify(describeSclElement(diffLN))
     ));
 });

--- a/describe.ts
+++ b/describe.ts
@@ -4,6 +4,7 @@ import { EnumType, EnumTypeDescription } from "./describe/EnumType.js";
 import { DAType, DATypeDescription } from "./describe/DAType.js";
 import { DOType, DOTypeDescription } from "./describe/DOType.js";
 import { LNodeType, LNodeTypeDescription } from "./describe/LNodeType.js";
+import { LN, LNDescription } from "./describe/LN.js";
 
 export type Description =
   | PrivateDescription
@@ -11,8 +12,8 @@ export type Description =
   | EnumTypeDescription
   | DATypeDescription
   | DOTypeDescription
-  | LNodeTypeDescription;
-
+  | LNodeTypeDescription
+  | LNDescription;
 const sclElementDescriptors: Partial<
   Record<string, (element: Element) => Description | undefined>
 > = {
@@ -22,6 +23,7 @@ const sclElementDescriptors: Partial<
   DAType,
   DOType,
   LNodeType,
+  LN,
 };
 
 export function describe(element: Element): Description | undefined {

--- a/describe/AbstractDataAttribute.spec.ts
+++ b/describe/AbstractDataAttribute.spec.ts
@@ -7,8 +7,18 @@ import { isDATypeDescription } from "./DAType.js";
 const scl = new DOMParser().parseFromString(
   `<SCL xmlns="http://www.iec.ch/61850/2003/SCL" >
     <DataTypeTemplates>      
-        <DAType id="someEqual" desc="someDesc">     
-          <BDA name="mag" desc="someEqual" bType="Struct" sAddr="someSAddr" type="AnalogueValue"/>
+        <DAType id="baseDAType" desc="someDesc">     
+          <BDA name="mag" desc="desc" bType="Struct" sAddr="someSAddr" type="AnalogueValue">
+            <Val sGroup="1">40.20</Val>
+            <Val sGroup="2">20.20</Val>
+          </BDA>
+          <BDA name="stVal" desc="someEnumBDA" bType="Enum" sAddr="someSAddr" type="someEnumType"/>
+        </DAType>
+        <DAType id="equalDAType" desc="someDesc">     
+          <BDA name="mag" desc="desc" bType="Struct" sAddr="someSAddr" type="AnalogueValue">
+            <Val sGroup="2">20.20</Val>
+            <Val sGroup="1">40.20</Val>
+          </BDA>
           <BDA name="stVal" desc="someEnumBDA" bType="Enum" sAddr="someSAddr" type="someEnumType"/>
         </DAType>
         <DAType id="AnalogueValue">
@@ -17,7 +27,7 @@ const scl = new DOMParser().parseFromString(
             </BDA>
         </DAType>
         <DAType id="daTypeCollection">
-          <BDA name="mag" desc="someEqual" bType="Struct" sAddr="someSAddr" type="AnalogueValue"/>
+          <BDA name="mag" desc="desc" bType="Struct" sAddr="someSAddr" type="AnalogueValue"/>
           <BDA name="cVal" desc="missingBType" />
           <BDA name="hstRangeC" desc="arrayBDA" bType="FLOAT32" count="34" />
           <BDA name="hstVal" desc="refArrayBDA" bType="FLOAT32" count="hstRangeC" />
@@ -41,6 +51,9 @@ const scl = new DOMParser().parseFromString(
   "application/xml"
 );
 
+const baseBDA = scl.querySelector(`#baseDAType>BDA`)!;
+const equalBDA = scl.querySelector(`#equalDAType>BDA`)!;
+
 const orphanBDA = new DOMParser()
   .parseFromString(
     `<BDA name="hstVal" desc="refArrayBDA" bType="FLOAT32" count="hstRangeC" />`,
@@ -57,13 +70,9 @@ const refMissingCount = scl.querySelector(`BDA[desc="missingRefArrayBDA"`)!;
 const refValidCount = scl.querySelector(`BDA[desc="refArrayBDA"`)!;
 const directCount = scl.querySelector(`BDA[desc="arrayBDA"`)!;
 
-const baseBDA = scl.querySelector(`BDA[desc="someEqual"`)!;
 const diffBDA1 = scl.querySelector(`BDA[desc="someDiff1"`)!;
 const diffBDA2 = scl.querySelector(`BDA[desc="someEnumBDA"`)!;
 const diffBDA3 = scl.querySelector(`BDA[desc="someDiff3"`)!;
-const equalBDA = scl.querySelector(
-  `DAType[id="daTypeCollection"] > BDA[desc="someEqual"`
-)!;
 
 describe("Description for SCL schema type tAbstractDataAttribute", () => {
   it("returns property sAddr with existing sAddr attribute", () => {
@@ -121,10 +130,10 @@ describe("Description for SCL schema type tAbstractDataAttribute", () => {
   });
 
   it("returns property val with existing Val children", () => {
-    expect(describeDAorSDAorDAI(diffBDA1).val.length).to.equal(1);
-    expect(describeDAorSDAorDAI(diffBDA3).val.length).to.equal(2);
-    expect(describeDAorSDAorDAI(diffBDA3).val[1].sGroup).to.equal(2);
-    expect(describeDAorSDAorDAI(diffBDA3).val[1].val).to.equal("55.00");
+    expect(describeDAorSDAorDAI(diffBDA1).vals.length).to.equal(1);
+    expect(describeDAorSDAorDAI(diffBDA3).vals.length).to.equal(2);
+    expect(describeDAorSDAorDAI(diffBDA3).vals[1].sGroup).to.equal(2);
+    expect(describeDAorSDAorDAI(diffBDA3).vals[1].val).to.equal("55.00");
   });
 
   it("returns same description with semantically equal BDA's", () =>

--- a/describe/AbstractDataAttribute.ts
+++ b/describe/AbstractDataAttribute.ts
@@ -1,8 +1,7 @@
-import { Description } from "../describe.js";
 import { DAType, DATypeDescription } from "./DAType.js";
 import { EnumType, EnumTypeDescription } from "./EnumType.js";
 import { NamingDescription, describeNaming } from "./Naming.js";
-import { ValDescription, describeVal } from "./Val.js";
+import { ValDescription, describeVal, compareBySGroup } from "./Val.js";
 
 export function isAbstractDataAttributeDescription(
   type: any
@@ -11,7 +10,7 @@ export function isAbstractDataAttributeDescription(
     "bType" in type &&
     "count" in type &&
     "valImport" in type &&
-    "val" in type &&
+    "vals" in type &&
     "valKind" in type
   );
 }
@@ -29,7 +28,7 @@ export interface AbstractDataAttributeDescription extends NamingDescription {
   valImport: boolean;
   /** (B)DA valKind attribute defaulting 0 */
   count: number;
-  val: ValDescription[];
+  vals: ValDescription[];
 }
 
 /** Get count from referenced sibling element */
@@ -59,7 +58,7 @@ export function describeDAorSDAorDAI(
     valKind: "Set",
     valImport: false,
     count: 0,
-    val: [],
+    vals: [],
   };
 
   const [sAddr, valKind, valImport, type, count] = [
@@ -89,9 +88,10 @@ export function describeDAorSDAorDAI(
     // count can be a reference to another sibling that has integer definition
     abstractDataAttributeDesc.count = siblingCount(element, count);
 
-  abstractDataAttributeDesc.val = Array.from(element.children)
+  abstractDataAttributeDesc.vals = Array.from(element.children)
     .filter((child) => child.tagName === "Val")
-    .map((val) => describeVal(val));
+    .map((val) => describeVal(val))
+    .sort(compareBySGroup);
 
   const referencedType = Array.from(
     element.closest("DataTypeTemplates")?.children ?? []

--- a/describe/LN.spec.ts
+++ b/describe/LN.spec.ts
@@ -1,0 +1,241 @@
+import { expect } from "chai";
+import { LN } from "./LN.js";
+import { LNodeType, isLNodeTypeDescription } from "./LNodeType.js";
+
+const scl = new DOMParser().parseFromString(
+  `<SCL xmlns="http://www.iec.ch/61850/2003/SCL" >
+      <IED name="IED1">
+        <AccessPoint name="AP1">
+            <Server>
+              <LDevice inst="lDevice1">
+                <LN0 lnClass="LLN0" inst="" lnType="LLN0">
+                    <DOI name="Beh" >
+                        <DAI name="stVal">
+                            <Val>on</Val>
+                        </DAI>
+                    </DOI>
+                </LN0>
+                <LN prefix="Meas" lnClass="MMXU" inst="1" lnType="MMXU" >
+                    <DOI name="A" >
+                        <SDI name="phsA" >
+                            <SDI name="cVal" >
+                                <SDI name="mag" >
+                                    <DAI name="f" >
+                                      <Val sGroup="1">10.10</Val>
+                                      <Val sGroup="3">30.30</Val>
+                                      <Val sGroup="2">20.20</Val>
+                                    </DAI>
+                                </SDI>
+                            </SDI>
+                        </SDI>
+                    </DOI>
+                </LN>
+                <LN desc="missingLnType" prefix="" lnClass="PTOC" inst="1" />
+                <LN desc="invalidLnType" prefix="" lnClass="PTOC" inst="1" lnType="invalidPointer"/>
+                <LN desc="invalidLnTypeDescription" prefix="" lnClass="PTOC" inst="1" lnType="invalidPTOC"/>
+              </LDevice>
+              <LDevice inst="lDevice2">
+                <LN0 lnClass="LLN0" inst="" lnType="LLN02" />
+                <LN prefix="Meas" lnClass="MMXU" inst="1" lnType="MMXU2" />
+              </LDevice>
+              <LDevice inst="lDevice3">
+                <LN0 lnClass="LLN0" inst="" lnType="LLN0" >
+                  <DOI name="Beh" >
+                    <DAI name="stVal">
+                      <Val>test</Val>
+                    </DAI>
+                  </DOI>
+                </LN0>
+                <LN prefix="Meas" lnClass="MMXU" inst="1" lnType="MMXU" >
+                    <DOI name="A" >
+                        <SDI >
+                          <Val sGroup="1">10.10</Val>
+                          <Val sGroup="3">30.30</Val>
+                          <Val sGroup="2">20.20</Val>
+                        </SDI>
+                    </DOI>
+                </LN>
+              </LDevice>
+              <LDevice inst="lDevice4" >
+                <LN0 lnClass="LLN0" inst="" lnType="diffLLN0" />
+                <LN lnClass="MMXU" inst="1" lnType="diffMMXU" >
+                  <DOI name="A" >
+                    <SDI name="phsA" >
+                      <SDI name="cVal" >
+                        <SDI name="mag" >
+                          <DAI name="f" >
+                            <Val sGroup="1">10.10</Val>
+                            <Val sGroup="3">30.30</Val>
+                            <Val sGroup="2">20.20</Val>
+                          </DAI>
+                        </SDI>
+                      </SDI>
+                    </SDI>
+                  </DOI>
+                </LN>
+              </LDevice>
+            </Server>
+        </AccessPoint>
+      </IED>
+      <DataTypeTemplates>
+        <LNodeType id="invalidPTOC" desc="desc" lnType="lnType" />
+        <LNodeType id="LLN0" desc="desc" lnClass="LLN0">     
+          <DO name="Beh" type="BehENS"/>
+        </LNodeType>
+        <LNodeType id="LLN02" desc="desc" lnClass="LLN0">     
+          <DO name="Beh" type="BehENS2"/>
+        </LNodeType>
+        <LNodeType id="diffLLN0" desc="desc" lnClass="LLN0">     
+          <DO name="Beh" type="diffBehENS"/>
+        </LNodeType>
+        <LNodeType id="MMXU" desc="desc" lnClass="MMXU">     
+          <DO name="A" type="WYE"/>
+        </LNodeType>
+        <LNodeType id="MMXU2" desc="desc" lnClass="MMXU">     
+          <DO name="A" type="WYE2"/>
+        </LNodeType>
+        <LNodeType id="diffMMXU" desc="desc" lnClass="MMXU">     
+          <DO name="A" type="diffWYE"/>
+        </LNodeType>
+        <DOType cdc="ENS" id="BehENS" >
+          <DA name="stVal" bType="Enum" type="BehModKind" fc="ST" >
+            <Val>off</Val>
+          </DA>
+        </DOType>
+        <DOType cdc="ENS" id="BehENS2" >
+          <DA name="stVal" bType="Enum" type="BehModKind" fc="ST" >
+            <Val>on</Val>
+          </DA>
+        </DOType>
+        <DOType id="diffBehENS" cdc="ENS" >
+          <DA name="stVal" bType="Enum" type="BehModKind" fc="ST" >
+            <Val>on</Val>
+          </DA>
+          <DA name="q" bType="Quality" fc="ST" />
+        </DOType>
+        <DOType id="WYE" cdc="WYE">
+          <SDO name="phsA" type="CMV" />
+        </DOType>
+        <DOType id="WYE2" cdc="WYE">
+          <SDO name="phsA" type="CMV2" />
+        </DOType>
+        <DOType id="diffWYE" cdc="WYE">
+          <SDO name="phsA" type="diffCMV" />
+          <SDO name="phsB" type="CMV" />
+        </DOType>
+        <DOType id="CMV" cdc="CMV" >
+          <DA name="cVal" bType="Struct" fc="MX" type="Vector"/>
+        </DOType>
+        <DOType id="CMV2" cdc="CMV" >
+          <DA name="cVal" bType="Struct" fc="MX" type="Vector2"/>
+        </DOType>
+        <DOType id="diffCMV" cdc="CMV" >
+          <DA name="cVal" bType="Struct" fc="MX" type="diffVector"/>
+          <DA name="q" bType="Quality" fc="MX" />
+        </DOType>
+        <DAType id="Vector" >
+          <BDA name="mag" bType="Struct" type="AnalogueValue" />
+        </DAType>
+        <DAType id="Vector2" >
+          <BDA name="mag" bType="Struct" type="AnalogueValue2" />
+        </DAType>
+        <DAType id="diffVector" >
+          <BDA name="mag" bType="Struct" type="AnalogueValue" />
+          <BDA name="ang" bType="Struct" type="AnalogueValue" />
+        </DAType>
+        <DAType id="AnalogueValue" >
+          <BDA name="f" bType="FLOAT32" >
+              <Val sGroup="3">60.60</Val>
+              <Val sGroup="1">10.10</Val>
+              <Val sGroup="2">40.10</Val>
+          </BDA>
+        </DAType>
+        <DAType id="AnalogueValue2" >
+          <BDA name="f" bType="FLOAT32" >
+              <Val sGroup="3">30.30</Val>
+              <Val sGroup="1">10.10</Val>
+              <Val sGroup="2">20.20</Val>
+          </BDA>
+        </DAType>
+        <EnumType id="BehModKind" >
+          <EnumVal ord="1">on</EnumVal>
+          <EnumVal ord="3">test</EnumVal>
+          <EnumVal ord="5">off</EnumVal>
+        </EnumType>
+        <EnumType id="diffBehModKind" >
+          <EnumVal ord="1">on</EnumVal>
+          <EnumVal ord="3">test</EnumVal>
+        </EnumType>
+      </DataTypeTemplates>
+    </SCL>`,
+  "application/xml"
+);
+
+const missingLnType = scl.querySelector('*[desc="missingLnType"]')!;
+const invalidLnType = scl.querySelector('*[desc="invalidLnType"]')!;
+const invalidLnTypeDescription = scl.querySelector(
+  '*[desc="invalidLnTypeDescription"]'
+)!;
+
+const baseLLN0 = scl.querySelector(
+  `LDevice[inst="lDevice1"] > *[lnClass="LLN0"][inst=""]`
+)!;
+const equalLLN0 = scl.querySelector(
+  'LDevice[inst="lDevice2"] > *[lnClass="LLN0"][inst=""]'
+)!;
+const diffLLN0 = scl.querySelector(
+  'LDevice[inst="lDevice3"] > *[lnClass="LLN0"][inst=""]'
+)!;
+const diffEnumType = scl.querySelector(
+  'LDevice[inst="lDevice4"] > *[lnClass="LLN0"][inst=""]'
+)!;
+const baseMMXU = scl.querySelector(
+  `LDevice[inst="lDevice1"] > *[lnClass="MMXU"][inst="1"]`
+)!;
+const equalMMXU = scl.querySelector(
+  `LDevice[inst="lDevice2"] > *[lnClass="MMXU"][inst="1"]`
+)!;
+const diffMMXU = scl.querySelector(
+  `LDevice[inst="lDevice3"] > *[lnClass="MMXU"][inst="1"]`
+)!;
+const diffSDO = scl.querySelector(
+  `LDevice[inst="lDevice4"] > *[lnClass="MMXU"][inst="1"]`
+)!;
+
+describe("Description for SCL schema type LN", () => {
+  it("returns undefined with missing lnType attribute", () =>
+    expect(LN(missingLnType)).to.be.undefined);
+
+  it("returns undefined with invalid lnType attribute", () =>
+    expect(LN(invalidLnType)).to.be.undefined);
+
+  it("returns undefined with invalid LNodeType description", () =>
+    expect(LN(invalidLnTypeDescription)).to.be.undefined);
+
+  it("return logical node structure in lnType key", () =>
+    expect(LN(baseLLN0)?.lnType).to.satisfy(isLNodeTypeDescription));
+
+  it("returns same description with semantically equal LN's", () => {
+    expect(JSON.stringify(LN(baseLLN0))).to.equal(
+      JSON.stringify(LN(equalLLN0))
+    );
+    expect(JSON.stringify(LN(baseMMXU))).to.equal(
+      JSON.stringify(LN(equalMMXU))
+    );
+  });
+
+  it("returns different description with unequal LN elements", () => {
+    expect(JSON.stringify(LN(baseLLN0))).to.not.equal(
+      JSON.stringify(LN(diffLLN0))
+    );
+    expect(JSON.stringify(LN(baseLLN0))).to.not.equal(
+      JSON.stringify(LN(diffEnumType))
+    );
+    expect(JSON.stringify(LN(baseMMXU))).to.not.equal(
+      JSON.stringify(LN(diffMMXU))
+    );
+    expect(JSON.stringify(LN(baseMMXU))).to.not.equal(
+      JSON.stringify(LN(diffSDO))
+    );
+  });
+});

--- a/describe/LN.ts
+++ b/describe/LN.ts
@@ -1,0 +1,102 @@
+import { AbstractDataAttributeDescription } from "./AbstractDataAttribute.js";
+import { LNodeType, LNodeTypeDescription } from "./LNodeType.js";
+import { NamingDescription, describeNaming } from "./Naming.js";
+import { describeVal, compareBySGroup } from "./Val.js";
+
+export interface LNDescription extends NamingDescription {
+  lnType: LNodeTypeDescription;
+}
+
+/** Returns leaf data attribute (BDA or DA) from
+ * LNodeTypeDescription containing vals
+ * @param path - parent DOI/SDI/DAI name attributes
+ * @param lNodeType - LNodeTypeDescription of the logical node
+ * */
+function getLeafDataAttribute(
+  path: string[],
+  lNodeType: LNodeTypeDescription
+): Object | undefined {
+  let index = 0;
+  let dataType: any = lNodeType;
+
+  while (path.length > index) {
+    if (dataType.dos)
+      // LNodeType->DO
+      dataType = dataType.dos[path[index]].type;
+    else if (dataType.sdos || dataType.das) {
+      // DOType
+      if (dataType.sdos[path[index]])
+        //SDO
+        dataType = dataType.sdos[path[index]].type;
+      else if (dataType.das[path[index]]) {
+        //DA
+        const da = dataType.das[path[index]];
+        if (da.bType === "Struct") dataType = da.type;
+        else return da;
+      }
+    } else {
+      // DAType->BDA
+      const bda = dataType.bdas[path[index]];
+      if (bda.bType === "Struct") dataType = bda.type;
+      else return bda;
+    }
+    index++;
+  }
+}
+
+function updateValues(
+  lNodeType: LNodeTypeDescription,
+  instanceValues: Record<string, Element[]>
+): LNodeTypeDescription {
+  Object.entries(instanceValues).forEach(([key, value]) => {
+    const leafDataAttribute = getLeafDataAttribute(key.split("."), lNodeType);
+
+    if (leafDataAttribute)
+      (leafDataAttribute as AbstractDataAttributeDescription).vals = value
+        .map((val) => describeVal(val))
+        .sort(compareBySGroup);
+  });
+
+  return lNodeType;
+}
+
+/** Path consisting of parents name attributes: e.g. ["Beh","stVal"] */
+function pathToInstanceValue(element: Element): string[] | undefined {
+  if (element.tagName === "LN" || element.tagName === "LN0") return [];
+
+  const parent = element.parentElement!;
+
+  if (element.tagName === "Val") return pathToInstanceValue(parent);
+
+  const parentPath = pathToInstanceValue(parent);
+  const name = element.getAttribute("name");
+
+  return parentPath && name ? [...parentPath, name] : undefined;
+}
+
+function instanceValues(ln: Element): Record<string, Element[]> {
+  const vals = ln.querySelectorAll("Val");
+
+  const instanceValues: Record<string, Element[]> = {};
+  vals.forEach((valElement) => {
+    const path = pathToInstanceValue(valElement)?.join(".");
+    if (path && instanceValues[path]) instanceValues[path].push(valElement);
+    if (path && !instanceValues[path]) instanceValues[path] = [valElement];
+  });
+
+  return instanceValues;
+}
+
+export function LN(element: Element): LNDescription | undefined {
+  const lNodeType = element.ownerDocument.querySelector(
+    `DataTypeTemplates > LNodeType[id="${element.getAttribute("lnType")}"]`
+  );
+  if (!lNodeType) return;
+
+  const lNodeTypeDescriptions = LNodeType(lNodeType);
+  if (!lNodeTypeDescriptions) return;
+
+  const lnType = updateValues(lNodeTypeDescriptions, instanceValues(element));
+
+  return { ...describeNaming(element), lnType };
+}

--- a/describe/LNodeType.ts
+++ b/describe/LNodeType.ts
@@ -2,6 +2,11 @@ import { sortRecord } from "../utils.js";
 import { DODescription, describeDO } from "./DODescription.js";
 import { NamingDescription, describeNaming } from "./Naming.js";
 
+export function isLNodeTypeDescription(
+  type: any
+): type is LNodeTypeDescription {
+  return "lnClass" in type && "dos" in type;
+}
 export interface LNodeTypeDescription extends NamingDescription {
   /** Required attribute lnClass */
   lnClass: string;

--- a/describe/Val.spec.ts
+++ b/describe/Val.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { describeVal } from "./Val.js";
+import { describeVal, compareBySGroup } from "./Val.js";
 
 const scl = new DOMParser().parseFromString(
   `<SCL
@@ -70,4 +70,26 @@ describe("Describes the SCL element Val", () => {
 
   it("ignores schema invalid sGroup definition", () =>
     expect(describeVal(invalidsGroup)).to.not.haveOwnProperty("sGroup"));
+});
+
+describe("Sort function for ValDescriptions", () => {
+  it("sorts with existing sGroup", () => {
+    const vals = [
+      { sGroup: 2, val: "val2" },
+      { sGroup: 1, val: "val1" },
+      { sGroup: 3, val: "val3" },
+    ];
+
+    expect(vals.sort(compareBySGroup)).to.deep.equal([
+      { sGroup: 1, val: "val1" },
+      { sGroup: 2, val: "val2" },
+      { sGroup: 3, val: "val3" },
+    ]);
+  });
+
+  it("does not sort with missing sGroup", () => {
+    const vals = [{ val: "val2" }, { val: "val1" }, { val: "val3" }];
+
+    expect(vals.sort(compareBySGroup)).to.deep.equal(vals);
+  });
 });

--- a/describe/Val.ts
+++ b/describe/Val.ts
@@ -1,3 +1,11 @@
+/** Sort `ValDescription` by `sGroup` attribute */
+export function compareBySGroup(a: ValDescription, b: ValDescription): number {
+  if (!a.sGroup || !b.sGroup) return 0;
+  else if (a.sGroup < b.sGroup) return -1;
+
+  return 1;
+}
+
 export type ValDescription = {
   /** Optional Val attribute sGroup */
   sGroup?: number;


### PR DESCRIPTION
Closes #24 and #24

#24 was necessary as we need to have sorted `Val` elements to make sure the update through instance `Val` in the `IED` section is correct
#24 also changes key `val` to key `vals` in `DADescription` and `BDADescription`.

#25 returns `LNDescription` with the data model structure only and all other potential child element are excluded such as `ReportControl`, `Inputs`, `LogControl` and others
 